### PR TITLE
1.0.1 up to 1.0.6 (from dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,10 @@ PiViewer is a lightweight, easy-to-configure slideshow viewer and controller des
 
 As the automated setup does not fully disable Wayland, please do it manually, follow these steps:
 
-1. **Edit `/boot/firmware/config.txt`:**  
+1. **Edit `/boot/firmware/config.txt`:**
+     ```
+     sudo nano /boot/firmware/config.txt
+     ```
    - **Do not include:**
      ```
      dtoverlay=vc4-fkms-v3d
@@ -47,7 +50,7 @@ As the automated setup does not fully disable Wayland, please do it manually, fo
      hdmi_force_hotplug=1
      ```
 
-2. **Disable Wayland in your display manager:**  
+3. **Disable Wayland in your display manager:**  
    For Raspberry Pi OS, run:
    ```
    sudo raspi-config
@@ -66,7 +69,7 @@ Install git
 sudo apt install git -y
 ```
 ```
-git clone https://github.com/tpersp/PiViewer.git
+git clone --branch dev https://github.com/tpersp/PiViewer.git
 ```
 Navigate to the project folder:
 ```

--- a/setup.sh
+++ b/setup.sh
@@ -77,7 +77,7 @@ else
 fi
 
 # -------------------------------------------------------
-# 3) Disable screen blanking
+# 3) Disable screen blanking and mouse cursor
 # -------------------------------------------------------
 echo
 echo "== Step 3: Disabling screen blanking via raspi-config =="
@@ -87,6 +87,8 @@ if [ $? -eq 0 ]; then
 else
   echo "Warning: raspi-config do_blanking failed. You may need to disable blanking manually."
 fi
+sudo sed -i -- "s/#xserver-command=X/xserver-command=X -nocursor/" /etc/lightdm/lightdm.conf
+
 
 # -------------------------------------------------------
 # 4) Prompt user for config


### PR DESCRIPTION
# Changes from **v1.0.1** to **v1.0.6**

## 1. Multi-Device Support
- **Role Selection**: A device can be set to **main** or **sub** via the Settings page.
- **Sub Device Sync**: Sub devices can retrieve their configuration from a main device (via `pull`) and receive updates from it (via `push`).
- **Device Manager** (on the main device): 
  - Add / remove sub devices.
  - Push / pull configurations.
  - Configure displays on remote devices.

## 2. Remote Configuration
- A new route, `/remote_configure/<dev_index>`, lets the main device edit a sub device’s display settings in the same layout as local display settings.

## 3. UI Enhancements
- **Shuffle Toggle**: Switched from a checkbox to a Yes/No dropdown, for consistency with other dropdown fields.
- **Mixed Mode (Multiple Folders)**: Introduced a drag-and-drop interface to select and reorder multiple subfolders for a single display.
- **Show Main IP on Sub Device**: If a device is set to `role = "sub"`, the top of the main page now displays the main device’s IP.

## 4. Prevent Self-Registration
- In the Device Manager, if the user attempts to add the main device’s own IP address as a sub device, the system skips it. This avoids self-referencing loops.

## 5. Miscellaneous Improvements
- **Version Bump**: From `APP_VERSION = "1.0.1"` to `APP_VERSION = "1.0.6"`.
- **Flexible Grid Layout**: Display cards now appear in up to three columns, adjusting automatically based on screen width.
- **Additional Logging & Code Cleanup**: 
  - More log messages for debugging multi-device sync.
  - Minor refactors to unify code style.

Overall, **v1.0.6** introduces the main/sub concept, remote display configuration, and a more polished UI for both single- and multi-device setups.
