### PR TITLE
Fix log filename reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ sudo journalctl -u controller.service
 - **Wrong screen**? Confirm you have multiple monitors recognized by X. PiViewer uses PySide6’s screen geometry, so make sure your environment is not on Wayland.
 - **Spotify issues**? Check `.spotify_cache` for the saved token. Re-authorize if needed.
 - **Overlay not transparent?** You need a compositor (like **picom**) running for real transparency.
-- **Check logs**: Look at `piviewer.log` (in your `VIEWER_HOME`) or `journalctl -u piviewer.service`.
+- **Check logs**: Look at `viewer.log` (in your `VIEWER_HOME`) or `journalctl -u piviewer.service`.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- correct viewer log filename in README

## Testing
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6840281fdbb4832b91fc79e700e8440b