### PR TITLE
Add gitignore for Python caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.pytest_cache/


### PR DESCRIPTION
## Summary
- ignore Python cache directories and files by adding `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68402f063a04832bb6e840b62f542ea8